### PR TITLE
Log warnings so sentry sees them as the same "group"

### DIFF
--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -297,7 +297,7 @@ class SmppTransceiverTransport(Transport):
         command_status = command_status or 'Unspecified'
         if error_message is None:
             log.warning(
-                "Could not retrieve failed message: %s" % (message_id,))
+                "Could not retrieve failed message: %s", message_id)
         else:
             yield self.delete_cached_message(message_id)
             yield self.publish_nack(message_id, command_status)
@@ -363,7 +363,7 @@ class SmppTransceiverTransport(Transport):
         if message is None:
             # We can't find this message, so log it and start again.
             log.warning(
-                "Could not retrieve throttled message: %s" % (message_id,))
+                "Could not retrieve throttled message: %s", message_id)
             self.check_stop_throttling(0)
         else:
             # Try handle this message again and leave the rest to our


### PR DESCRIPTION
If we use proper log message formatting, then raven (Sentry), will group all of these warnings together, rather than thinking that each warning is a separate interesting event.

https://docs.sentry.io/clients/python/integrations/logging/#usage

![image](https://user-images.githubusercontent.com/4413/35530688-cd19190a-0502-11e8-9590-49a705a4bd4c.png)
