### PR TITLE
Send event to sentry, details to logging (Kibana, et al)

### DIFF
--- a/vumi/transports/smpp/smpp_transport.py
+++ b/vumi/transports/smpp/smpp_transport.py
@@ -296,8 +296,10 @@ class SmppTransceiverTransport(Transport):
         error_message = yield self.get_cached_message(message_id)
         command_status = command_status or 'Unspecified'
         if error_message is None:
-            log.warning(
-                "Could not retrieve failed message: %s", message_id)
+            # send the warning to Sentry
+            log.warning("Could not retrieve failed message")
+            # but log the message so we can find the message_id if needed
+            log.msg("Could not retrieve failed message: %s" % message_id)
         else:
             yield self.delete_cached_message(message_id)
             yield self.publish_nack(message_id, command_status)
@@ -362,8 +364,8 @@ class SmppTransceiverTransport(Transport):
         message = yield self.get_cached_message(message_id)
         if message is None:
             # We can't find this message, so log it and start again.
-            log.warning(
-                "Could not retrieve throttled message: %s", message_id)
+            log.warning("Could not retrieve throttled message")
+            log.msg("Could not retrieve throttled message: %s" % message_id)
             self.check_stop_throttling(0)
         else:
             # Try handle this message again and leave the rest to our


### PR DESCRIPTION
I've poked around a bit, and I don't see an easy way to log these messages in a groupable way to sentry using the normal Python logging and Sentry mechanisms. In short, vumi decides what to send to sentry here: https://github.com/hnec-vr/vumi/blob/develop/vumi/sentry.py#L136-L149

So it seems to throw away anything we might put into the log event object with keywords, for example. (I tested on the server to confirm: http://10.10.40.6:9000/hnec/libyavotes-vumi/issues/1450/ )

Instead, I decided to send just the event to Sentry (using static text), and send the full message with ID to our normal logging, so we could search in Kibana for it, if really needed.

Probably would have been fine to just remove the warning calls and rely just on Kibana, but I'm interested to see how often these events occur and if there is any pattern, which Sentry does nicely.